### PR TITLE
Fix possible TypeError: Cannot call method 'map' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ exports.create = function(_config) {
                             if(err){
                                 return reject(err);
                             }
-                            if(m === 'search' && data.num_found){
+                            if(m === 'search' && data.num_found && data.docs){
                                 data.docs = data.docs.map(function(doc) {
                                     var d = {};
                                     doc.fields.forEach(function(field) {


### PR DESCRIPTION
In such use case:
```js
riakClient.search({
  q: 'query',
  start: offset
})
```
If resulting docset has matching documents, but number of docs is less than required offset, an error will occur - ```TypeError: Cannot call method 'map' of undefined```

The result will look like:
```js
{ max_score: 1087496187, num_found: 2 }
```